### PR TITLE
FIX: 404 error when editing an expanded reply

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/post.js
+++ b/app/assets/javascripts/discourse/app/widgets/post.js
@@ -486,7 +486,7 @@ createWidget("post-contents", {
         this.state.repliesBelow = posts.map((p) => {
           let result = transformWithCallbacks(p);
           result.shareUrl = `${topicUrl}/${p.post_number}`;
-          result.asPost = this.store.createRecord("post", p);
+          result.asPost = this.store.createRecord("post", result);
           return result;
         });
       });
@@ -684,7 +684,7 @@ createWidget("post-article", {
           this.state.repliesAbove = posts.map((p) => {
             let result = transformWithCallbacks(p);
             result.shareUrl = `${topicUrl}/${p.post_number}`;
-            result.asPost = this.store.createRecord("post", p);
+            result.asPost = this.store.createRecord("post", result);
             return result;
           });
         });


### PR DESCRIPTION
Repro steps in https://meta.discourse.org/t/random-404-errors-when-editing-posts/167887/9

We were saving the untransformed result in `asPost`, and that was causing
the REST model to be of type `post-reply` or `post-reply-history`, which
meant the PUT request was going to the wrong endpoint.

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in Javascript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
